### PR TITLE
feat: log query

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -22,6 +22,7 @@ func Ginzap(logger *zap.Logger, timeFormat string, utc bool) gin.HandlerFunc {
 		start := time.Now()
 		// some evil middlewares modify this values
 		path := c.Request.URL.Path
+		query := c.Request.URL.RawQuery
 		c.Next()
 
 		end := time.Now()
@@ -40,6 +41,7 @@ func Ginzap(logger *zap.Logger, timeFormat string, utc bool) gin.HandlerFunc {
 				zap.Int("status", c.Writer.Status()),
 				zap.String("method", c.Request.Method),
 				zap.String("path", path),
+				zap.String("query", query),
 				zap.String("ip", c.ClientIP()),
 				zap.String("user-agent", c.Request.UserAgent()),
 				zap.String("time", end.Format(timeFormat)),


### PR DESCRIPTION
The default Gin's logger add the query in the path. I decided to keep it separated, to allow aggregation by path with different queries.