### PR TITLE
add RecoveryWithZap

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gin-contrib/zap"
+	ginzap "github.com/LinkinStars/zap"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
@@ -20,9 +20,18 @@ func main() {
 	//   - RFC3339 with UTC time format.
 	r.Use(ginzap.Ginzap(logger, time.RFC3339, true))
 
+	// Logs all panic to error log
+	//   - stack means whether output the stack info.
+	r.Use(ginzap.RecoveryWithZap(logger, true))
+
 	// Example ping request.
 	r.GET("/ping", func(c *gin.Context) {
 		c.String(200, "pong "+fmt.Sprint(time.Now().Unix()))
+	})
+
+	// Example when panic happen.
+	r.GET("/panic", func(c *gin.Context) {
+		panic("An unexpected error happen!")
 	})
 
 	// Listen and Server in 0.0.0.0:8080

--- a/zap.go
+++ b/zap.go
@@ -3,6 +3,12 @@
 package ginzap
 
 import (
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -48,5 +54,58 @@ func Ginzap(logger *zap.Logger, timeFormat string, utc bool) gin.HandlerFunc {
 				zap.Duration("latency", latency),
 			)
 		}
+	}
+}
+
+// RecoveryWithZap returns a gin.HandlerFunc (middleware)
+// that recovers from any panics and logs requests using uber-go/zap.
+// All errors are logged using zap.Error().
+// stack means whether output the stack info.
+// The stack info is easy to find where the error occurs but the stack info is too large.
+func RecoveryWithZap(logger *zap.Logger, stack bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				// Check for a broken connection, as it is not really a
+				// condition that warrants a panic stack trace.
+				var brokenPipe bool
+				if ne, ok := err.(*net.OpError); ok {
+					if se, ok := ne.Err.(*os.SyscallError); ok {
+						if strings.Contains(strings.ToLower(se.Error()), "broken pipe") || strings.Contains(strings.ToLower(se.Error()), "connection reset by peer") {
+							brokenPipe = true
+						}
+					}
+				}
+
+				httpRequest, _ := httputil.DumpRequest(c.Request, false)
+				if brokenPipe {
+					logger.Error(c.Request.URL.Path,
+						zap.String("error", err.(string)),
+						zap.String("request", string(httpRequest)),
+					)
+					// If the connection is dead, we can't write a status to it.
+					c.Error(err.(error)) // nolint: errcheck
+					c.Abort()
+					return
+				}
+
+				if stack {
+					logger.Error("[Recovery from panic]",
+						zap.Time("time", time.Now()),
+						zap.String("error", err.(string)),
+						zap.String("request", string(httpRequest)),
+						zap.String("stack", string(debug.Stack())),
+					)
+				} else {
+					logger.Error("[Recovery from panic]",
+						zap.Time("time", time.Now()),
+						zap.String("error", err.(string)),
+						zap.String("request", string(httpRequest)),
+					)
+				}
+				c.AbortWithStatus(http.StatusInternalServerError)
+			}
+		}()
+		c.Next()
 	}
 }


### PR DESCRIPTION
I found a problem. Using ginzap.Ginzap, when the panic occurs the log, didn't output by zap so I can't find any log. Because of the router.Use(gin.Recovery()) will be triggered. I imitated gin.RecoveryWithWriter and made ginzap.RecoveryWithZap. 

Example:
router.Use(ginzap.RecoveryWithZap(logger, true))

If you like, you can add an example to your main.go.😁