### PR TITLE
ginzap definition added to the code example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import (
   "fmt"
   "time"
 
-  "github.com/gin-contrib/zap"
+  ginzap "github.com/gin-contrib/zap"
   "github.com/gin-gonic/gin"
   "go.uber.org/zap"
 )


### PR DESCRIPTION
Code example did not define `ginzap`.