### PR TITLE
Add request-id to output if X-Request-Id header is present

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -71,6 +71,9 @@ func GinzapWithConfig(logger *zap.Logger, conf *Config) gin.HandlerFunc {
 					zap.String("user-agent", c.Request.UserAgent()),
 					zap.Duration("latency", latency),
 				}
+				if requestId := c.Writer.Header().Get("X-Request-Id"); requestId != "" {
+					fields = append(fields, zap.String("request-id", requestId))
+				}
 				if conf.TimeFormat != "" {
 					fields = append(fields, zap.String("time", end.Format(conf.TimeFormat)))
 				}


### PR DESCRIPTION
Before:

```
{"level":"info","ts":1645300140.072392,"caller":"zap@v0.0.2/zap.go:80","msg":"/api/v1/extractors","status":200,"method":"POST","path":"/api/v1/extractors","query":"","ip":"127.0.0.1","user-agent":"curl/7.64.1","latency":0.00029637,"request-id":"58badad1-0c5e-4bfd-893b-cdf4e0686d32","time":"2022-02-19T19:49:00Z"}
```

After:

With `X-Request-Id` provided:

```
❯ curl -v -H 'X-Request-Id: e72b5b68-21e4-4f23-be4f-1a4441f3398c' -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:8088/api/v1/extractors
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8088 (#0)
> POST /api/v1/extractors HTTP/1.1
> Host: 127.0.0.1:8088
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 2
>
* upload completely sent off: 2 out of 2 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Tonic-Response: OK
< X-Request-Id: e72b5b68-21e4-4f23-be4f-1a4441f3398c
< Date: Sat, 19 Feb 2022 19:49:31 GMT
< Content-Length: 56

{"level":"info","ts":1645300140.072392,"caller":"zap@v0.0.2/zap.go:80","msg":"/api/v1/extractors","status":200,"method":"POST","path":"/api/v1/extractors","query":"","ip":"127.0.0.1","user-agent":"curl/7.64.1","latency":0.00029637,"request-id":"58badad1-0c5e-4bfd-893b-cdf4e0686d32","time":"2022-02-19T19:49:00Z"}
```

Without `X-Request-Id` provided:

```
❯ curl -v -H 'Content-Type: application/json' -d '{}' http://127.0.0.1:8088/api/v1/extractors
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8088 (#0)
> POST /api/v1/extractors HTTP/1.1
> Host: 127.0.0.1:8088
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 2
>
* upload completely sent off: 2 out of 2 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Tonic-Response: OK
< Date: Sat, 19 Feb 2022 19:57:32 GMT
< Content-Length: 56
<

{"level":"info","ts":1645300652.5770319,"caller":"tonic/middleware.go:59","msg":"response","headers":{"Content-Type":["application/json; charset=utf-8"],"Tonic-Response":["OK"]},"path":"/api/v1/extractors"}

```

Compatible with https://github.com/gin-contrib/requestid