### PR TITLE
Add request meta data when logging request error.

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -56,24 +56,25 @@ func GinzapWithConfig(logger *zap.Logger, conf *Config) gin.HandlerFunc {
 				end = end.UTC()
 			}
 
+			fields := []zapcore.Field{
+				zap.Int("status", c.Writer.Status()),
+				zap.String("method", c.Request.Method),
+				zap.String("path", path),
+				zap.String("query", query),
+				zap.String("ip", c.ClientIP()),
+				zap.String("user-agent", c.Request.UserAgent()),
+				zap.Duration("latency", latency),
+			}
+			if conf.TimeFormat != "" {
+				fields = append(fields, zap.String("time", end.Format(conf.TimeFormat)))
+			}
+
 			if len(c.Errors) > 0 {
 				// Append error field if this is an erroneous request.
 				for _, e := range c.Errors.Errors() {
-					logger.Error(e)
+					logger.Error(e, fields...)
 				}
 			} else {
-				fields := []zapcore.Field{
-					zap.Int("status", c.Writer.Status()),
-					zap.String("method", c.Request.Method),
-					zap.String("path", path),
-					zap.String("query", query),
-					zap.String("ip", c.ClientIP()),
-					zap.String("user-agent", c.Request.UserAgent()),
-					zap.Duration("latency", latency),
-				}
-				if conf.TimeFormat != "" {
-					fields = append(fields, zap.String("time", end.Format(conf.TimeFormat)))
-				}
 				logger.Info(path, fields...)
 			}
 		}


### PR DESCRIPTION
This PR adds the same request data (path, query etc) that is added to the normal request log to the one written when a request has errors. This is helpful for applications wishing to see what endpoint logged an error - for example by returning 400.