### PR TITLE
chore: remove duplication log to msg

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -89,12 +89,12 @@ func GinzapWithConfig(logger ZapLogger, conf *Config) gin.HandlerFunc {
 					logger.Error(e, fields...)
 				}
 			} else {
-                zl, ok := logger.(*zap.Logger)
-                if ok {
-                    zl.Log(conf.DefaultLevel, path, fields...)
-                } else {
-                    logger.Error(path, fields...)
-                }
+				zl, ok := logger.(*zap.Logger)
+				if ok {
+					zl.Log(conf.DefaultLevel, "", fields...)
+				} else {
+					logger.Error(path, fields...)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fields already contain `path`, so we don't need to log `path` on msg again.

https://github.com/gin-contrib/zap/blob/d017ca5e380d72e623151e4e90f073936dbaf20f/zap.go#L69-L77

I don't think this will cause a break change because we can't rely on the `msg` field.

BTW, fix the code from space to tab