### PR TITLE
Log errors once

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -37,6 +37,7 @@ type Config struct {
 	SkipPathRegexps []*regexp.Regexp
 	Context         Fn
 	DefaultLevel    zapcore.Level
+	LogErrorsOnce   bool
 	// skip is a Skipper that indicates which logs should not be written.
 	// Optional.
 	Skipper Skipper
@@ -116,9 +117,13 @@ func GinzapWithConfig(logger ZapLogger, conf *Config) gin.HandlerFunc {
 			}
 
 			if len(c.Errors) > 0 {
-				// Append error field if this is an erroneous request.
-				for _, e := range c.Errors.Errors() {
-					logger.Error(e, fields...)
+				if conf.LogErrorsOnce {
+					logger.Error(c.Errors.String(), fields...)
+				} else {
+					// Append error field if this is an erroneous request.
+					for _, e := range c.Errors.Errors() {
+						logger.Error(e, fields...)
+					}
 				}
 			} else {
 				if zl, ok := logger.(*zap.Logger); ok {

--- a/zap_test.go
+++ b/zap_test.go
@@ -2,6 +2,7 @@ package ginzap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -222,5 +223,42 @@ func TestSkipPathRegexps(t *testing.T) {
 	pathStr := logLine.Context[2].String
 	if pathStr != testPath {
 		t.Fatalf("logged path should be /test but %s", pathStr)
+	}
+}
+
+func TestLoggerLogErrorsOnce(t *testing.T) {
+	errorPath := "/error"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := gin.New()
+
+	logger, loggerObserved := buildDummyLogger()
+	r.Use(GinzapWithConfig(logger, &Config{
+		LogErrorsOnce: true,
+	}))
+
+	r.GET(errorPath, func(c *gin.Context) {
+		c.Error(errors.New("error1"))
+		c.Error(errors.New("error2"))
+
+		c.JSON(500, nil)
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(ctx, "GET", errorPath, nil)
+	r.ServeHTTP(res, req)
+
+	if res.Code != 500 {
+		t.Fatalf("request /error status code (%d)", res.Code)
+	}
+
+	if len(loggerObserved.All()) != 1 {
+		t.Fatalf("Log should be 1 line but there're %d", len(loggerObserved.All()))
+	}
+
+	logLine := loggerObserved.All()[0]
+	if logLine.Message != "Error #01: error1\nError #02: error2\n" {
+		t.Fatalf("logged message should be \"Error #01: error1\nError #02: error2\" but %s", logLine.Message)
 	}
 }


### PR DESCRIPTION
Hi!

Thank you for your amazing work!
Currently, if in some handler you have more than one (assume `n`) call to `c.Error(someErr)`, this middleware will create `n` separate log entries. This might not be a frequent use case, but with `Gin`, it is possible to do so (and we do in our projects).

In this pull request, I’ve added a `LogErrorsOnce` config option. If set to false (default), the old behavior remains unchanged. However, if set to true, only one `logger.Error(c.Errors.String(), fields...)` will be called.

What do you think?